### PR TITLE
chore: downgrade go version to 1.20

### DIFF
--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -31,7 +31,7 @@ func CheckError(t *testing.T, err error) {
 }
 
 func udpFlowCreateProg(t *testing.T, flows, srcPort int, dstIP string, dstPort int) {
-	for i := range flows {
+	for i := 0; i < flows; i++ {
 		ServerAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", dstIP, dstPort))
 		CheckError(t, err)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vishvananda/netlink
 
-go 1.23
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
ER 需求 go version 为 1.20，这里将 go 版本降回 go 1.20